### PR TITLE
GitHub Actions workflows for Lambda deployments now set environment variables for the execution role and reference the IAM role from the environment variables.

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -20,6 +20,7 @@ permissions:
   id-token: write
 
 env:
+  LAMBDA_EXECUTION_ROLE: ${{ secrets.LAMBDA_EXECUTION_ROLE }}
   ROLE_TO_ASSUME: ${{ secrets.ROLE_TO_ASSUME }}
 
 jobs:
@@ -48,5 +49,5 @@ jobs:
           code-artifacts-dir: src/lambda
           function-name: lambda_function
           handler: lambda_function.lambda_handler
-          role: arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+          role: "${{ env.LAMBDA_EXECUTION_ROLE }}"
           runtime: python3.13


### PR DESCRIPTION
This pull request updates the deployment workflow for the Lambda function to use a configurable execution role via a GitHub secret, improving security and flexibility.

Workflow configuration improvements:

* Added the `LAMBDA_EXECUTION_ROLE` environment variable to `.github/workflows/lambda-deploy.yml`, sourcing its value from a GitHub secret for secure role management.
* Updated the Lambda deployment step to use the `LAMBDA_EXECUTION_ROLE` environment variable instead of a hardcoded AWS managed policy ARN, allowing for custom role specification.