### PR TITLE
Add tree tool to Dockerfile and format AWS credentials setup in workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -100,6 +100,7 @@ RUN dnf update -y && \
     python3.12-3.12.11 \
     python3.12-pip-23.2.1 \
     tar-1.34 \
+    tree-1.8.0 \
     unzip-6.0 \
     xz-5.2.5 && \
     dnf clean all

--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -36,14 +36,16 @@ jobs:
           persist-credentials: "false"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a #v4.3.1
+        # yamllint disable-line rule:line-length
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
           aws-region: ap-northeast-1
           mask-aws-account-id: true
           role-to-assume: "${{ env.ROLE_TO_ASSUME }}"
 
       - name: Deploy Lambda Function
-        uses: aws-actions/aws-lambda-deploy@adf3041f6b285d61334ae702e0b6e8e1080f9eb0 #v1
+        # yamllint disable-line rule:line-length
+        uses: aws-actions/aws-lambda-deploy@adf3041f6b285d61334ae702e0b6e8e1080f9eb0  # v1
         with:
           architectures: arm64
           code-artifacts-dir: src/lambda


### PR DESCRIPTION
Include the tree tool in the Dockerfile and improve the formatting of AWS credentials configuration in the Lambda deployment workflow.